### PR TITLE
Upgrade to jupyterlab 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0-rc.0",
-    "@jupyterlab/console": "^1.0.0-rc.0",
-    "@jupyterlab/notebook": "^1.0.0-rc.0"
+    "@jupyterlab/application": "^1.0.0",
+    "@jupyterlab/console": "^1.0.0",
+    "@jupyterlab/notebook": "^1.0.0"
   },
   "devDependencies": {
     "husky": "^2.5.0",


### PR DESCRIPTION
This just remove the `rc` from the jupyterlab package versions 👍