### PR TITLE
Add constraint to README installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ for helping us build this extension!
 
 ## ⌛️ Installation
 
-To use this extension, you need [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) >= 2.0.0 ⚠️ and [Prodigy](https://prodi.gy).
+To use this extension, you need
+[JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) >= 2.0.0, < 3.0.0 ⚠️
+and [Prodigy](https://prodi.gy).
 
 ```bash
-pip install jupyterlab>=2.0.0
+pip install "jupyterlab>=2.0.0,<3.0.0"
 ```
 
 ```bash


### PR DESCRIPTION
jupyterlab_prodigy doesn't work on jupyterlab>=3.0.0. So we need to add a constraint in the installation step to avoid any build errors. 